### PR TITLE
Update readme to use the correct workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cd tabor-gatsby-theme
 yarn
 
 # Start the site on http://localhost:8000
-yarn workspace starter develop
+yarn workspace site develop
 ```
 
 ## For Help


### PR DESCRIPTION
The workspace configured in `package.json` is `site` but the readme uses `starter`. This pull request updates the readme to match.