### PR TITLE
(Fix) Add in SEO to posts archive template

### DIFF
--- a/packages/gatsby-theme-tabor/src/templates/posts/archive.js
+++ b/packages/gatsby-theme-tabor/src/templates/posts/archive.js
@@ -2,6 +2,8 @@ import React from "react"
 import Layout from "../../components/Layout"
 import PostEntry from "../../components/PostEntry"
 import Pagination from "../../components/Pagination"
+import SEO from '../../components/SEO';
+
 
 const BlogArchive = props => {
   const {
@@ -9,6 +11,7 @@ const BlogArchive = props => {
   } = props
   return (
     <Layout>
+      <SEO/>
       {nodes && nodes.map(post => <PostEntry key={post.postId} post={post} />)}
       <Pagination
         pageNumber={pageNumber}


### PR DESCRIPTION
## Main Fix:
This fixes the "no title, no meta description" error from Lighthouse in Chrome audits.

## Description
As I was setting this theme up for use on my personal blog, I kept getting an error that said there was no `<title>` tag and no `<meta description>` tag. Lighthouse was showing an SEO score of 80, but only on the home page.

It looks like all that was needed was to have the SEO component pulled in. 

Now, Lighthouse scores are at 💯 !!! 🎉

